### PR TITLE
Add GitHub Action Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Souce (is this a typo?)
+    - name: Checkout Source
       uses: actions/checkout@v4
     - name: Setup Java
       uses: actions/setup-java@v4


### PR DESCRIPTION
Hallo @thehaddl, bei nächten Schritt helfe ich Dir und habe daher diesen Pull Request vorbereitet.

Wir fügen Continuous Integration (CI) zu dem Projekt hinzu. Durch die Definition eines sogenannten "Workflows" führt GitHub automatisch den Maven Build aus. Wenn sich ein Fehler eingeschlichen hat, weil zum Beipiel der Code nicht kompiliert, bekommst Du automatisch eine Notifikation. Dadurch ist sichergestellt, dass der auf GitHub publizierte Code jederzeit formalen Qualitätsanforderungen entspricht.

Du kannst diesen Pull-Request nun reviewen auf dem "Files changed" Tag. Vielleicht findest Du ja einen Fehler ;)

Du kannst dann direkt auf der fehlerhaften Zeile einen Kommentar hinterlassen, damit der Autor (ich) den Fehler behebt, bevor wir das mergen.

